### PR TITLE
Tools to remove inactive users

### DIFF
--- a/graphql/permissions.ts
+++ b/graphql/permissions.ts
@@ -24,7 +24,7 @@ export const permissions= shield({
         getUsers: isAdmin,
         getLogs: isAdmin,
         getUser: isAdmin,
-        getUsersWithoutGames: isAdmin
+        getUsersWithoutGames: isAdmin,
     },
 
     Mutation: {
@@ -33,6 +33,8 @@ export const permissions= shield({
         createUser: allow,
         restoreAccount: allow,
         sendFeedback: allow,
+
+        deleteAccounts: isAdmin
     },
 }, {
     async fallbackError(thrownThing) {

--- a/graphql/users/mutations.ts
+++ b/graphql/users/mutations.ts
@@ -47,7 +47,16 @@ export default {
             } else {
                 Log(`Deleting account ${context.user.name} failed`, LogType.ERROR, LogContext.USER_DELETION);
             }
-            return response;
+            return Boolean(response);
+        },
+        deleteAccounts: async (_root: unknown, args: { userIds: ID[] }, context: ContextWithUser) => {
+            const response = await userService.deleteAccount(args.userIds);
+            if (response) {
+                Log(`${response} accounts deleted`, LogType.SUCCESS, LogContext.USER_DELETION, context.user.id);
+            } else {
+                Log(`Deleting multiple account failed!`, LogType.ERROR, LogContext.USER_DELETION, context.user.id);
+            }
+            return Boolean(response);
         },
         login: async (_root: unknown, args: {user: string, password: string, pushToken?: string}) => {
             if (!process.env.TOKEN_KEY) {

--- a/graphql/users/queries.ts
+++ b/graphql/users/queries.ts
@@ -19,13 +19,13 @@ export default {
             }
 
             const users = await userService.getUsersWithoutGames(createdBefore);
-            const mapepdUsers = users.map(user => ({
+            const mappedUsers = users.map(user => ({
                 id: user.id,
                 name: user.name,
                 createdAt: user.createdAt
             }));
 
-            return mapepdUsers;
+            return mappedUsers;
         },
         getUsers: async () => {
             try {

--- a/graphql/users/typeDefs.ts
+++ b/graphql/users/typeDefs.ts
@@ -53,7 +53,7 @@ export default gql`
 
     type Query {
         getMe: User
-        getUsersWithoutGames: [UserWithoutGames!]!
+        getUsersWithoutGames(createdBefore: String!): [UserWithoutGames!]!
         getUsers: [User]!
         getUser (userId: ID!): User
         searchUser(search: String!): SearchUserResponse!
@@ -70,7 +70,8 @@ export default gql`
         addFriend(friendId: ID, friendName: String): Boolean
         removeFriend(friendId: ID!): Boolean
         login(user: String!, password: String!, pushToken: String): String!
-        deleteAccount: Boolean
+        deleteAccount: Boolean!
+        deleteAccounts(userIds: [ID!]!): Boolean!
         changeSettings(blockFriendRequests: Boolean, password: String, blockStatsSharing: Boolean, userId: ID, groupName: String, email: String, groupJoinedDate: String): User
         changeUsername(newUsername: String!): User!
         restoreAccount(name: String, restoreCode: String, password: String): Boolean

--- a/graphql/users/types.ts
+++ b/graphql/users/types.ts
@@ -33,3 +33,7 @@ export type GetPastActivityArgs = {
     year?: number
     userId?: ID
 }
+
+export type GetUsersWithoutGamesArgs = {
+    createdBefore: string
+}

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -10,11 +10,12 @@ const getUsers = async (): Promise<(Document & User)[]> => {
     return users;
 };
 
-const getUsersWithoutGames = async (): Promise<(Document & User)[]> => {
+const getUsersWithoutGames = async (createdBefore?: Date): Promise<(Document & User)[]> => {
     const users = await Users.find<Document & User>({
         _id: {
             $nin: await Game.distinct('scorecards.user')
-        }
+        },
+        createdAt: { $lt: createdBefore }
     });
     return users;
 };
@@ -89,29 +90,31 @@ const removeFriend = async (removeFromUserId: ID, userIdToRemove: ID) => {
         return false;
     }
 };
-const deleteAccount = async (userId: ID) => {
+const deleteAccount = async (userIds: ID | ID[]) => {
+    const ids = Array.isArray(userIds) ? userIds : [userIds];
+
     try {
         // Poistetaan kaikki käyttäjän tuloskortit peleistä
         await Game.updateMany(
             {
-                'scorecards.user': userId
+                'scorecards.user': { $in: ids }
             },
             {
-                $pull: { scorecards: { user: userId } }
+                $pull: { scorecards: { user: { $in: ids } } }
             },
         );
         // Poistetaan kaikki kaveruudet
         await Users.updateMany(
             {
-                'friends': userId
+                'friends': { $in: ids }
             },
             {
-                $pull: { friends: userId }
+                $pull: { friends: { $in: ids } }
             }
         );
         // Poistetaan tunnukset
-        await Users.findByIdAndRemove(userId);
-        return true;
+        await Users.deleteMany({_id: { $in: ids }});
+        return ids.length;
     } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);

--- a/services/userService.ts
+++ b/services/userService.ts
@@ -10,7 +10,7 @@ const getUsers = async (): Promise<(Document & User)[]> => {
     return users;
 };
 
-const getUsersWithoutGames = async (createdBefore?: Date): Promise<(Document & User)[]> => {
+const getUsersWithoutGames = async (createdBefore: Date): Promise<(Document & User)[]> => {
     const users = await Users.find<Document & User>({
         _id: {
             $nin: await Game.distinct('scorecards.user')


### PR DESCRIPTION
- add createdBefore arg to getUsersWithoutGames query
- add mutation to delete multiple users at once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability for admins to delete multiple user accounts at once via a new batch deletion mutation.
  * Enhanced the user query to allow filtering users without games based on a specified creation date.

* **Improvements**
  * The single account deletion mutation now consistently returns a boolean value.
  * Improved error handling for user queries to provide clearer feedback on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->