### PR TITLE
add groupJoinedDate to SafeUser

### DIFF
--- a/graphql/users/typeDefs.ts
+++ b/graphql/users/typeDefs.ts
@@ -40,6 +40,7 @@ export default gql`
         id: ID!
         name: String!
         groupName: String
+        groupJoinedDate: String
         blockFriendRequests: Boolean
     }
     type UserWithoutGames {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new GraphQL field groupJoinedDate on user-related types, enabling clients to query when a user joined their group.
  * Enhances user and group views by allowing display of join dates where needed.
  * Backward-compatible change; no existing fields were modified or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->