### PR TITLE
Fix incorrect acc type

### DIFF
--- a/graphql/users/typeDefs.ts
+++ b/graphql/users/typeDefs.ts
@@ -56,7 +56,7 @@ export default gql`
 
   type Point {
     coordinates: [Float]
-    acc: Int
+    acc: Float
   }
 
   type MeasuredThrow {
@@ -67,13 +67,13 @@ export default gql`
   }
 
   input PointInput {
-    coordinates: [Float]
-    acc: Int
+    coordinates: [Float!]!
+    acc: Float!
   }
 
   input MeasuredThrowInput {
-    startingPoint: PointInput
-    landingPoint: PointInput
+    startingPoint: PointInput!
+    landingPoint: PointInput!
   }
 
   type Query {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Tightened GraphQL input validation for measured throw submissions: coordinates lists and starting/landing points are now required.
  - Increased precision for the accuracy value; clients must send decimals (floats) instead of integers.
  - Requests missing these fields or using invalid types will now return clearer validation errors.

- Documentation
  - Updated API usage notes to reflect required fields and float-based accuracy input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->